### PR TITLE
Build system rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ Rules for working with .NET CLI tools:
 - 🔄 Managing tool versions and updates
 - ✨ Best practices for tool development
 
+### 🔄 [CI/CD](ci-cd/)
+Rules for build and deployment processes:
+- 🏗️ Build system configuration and best practices
+- 📝 Release management and versioning
+- 🔐 Code signing and security
+- 🚀 Pipeline configuration (GitHub Actions & Azure DevOps)
+- 📦 Package publishing
+
 ### 🎛️ [.NET SDK Management](dotnet-sdk/)
 Rules for managing .NET solutions and dependencies:
 - 🎯 SDK version control and configuration

--- a/ci-cd/README.md
+++ b/ci-cd/README.md
@@ -1,0 +1,32 @@
+# CI/CD Rules and Best Practices
+
+This directory contains detailed rules and best practices for CI/CD processes in .NET projects. These rules are designed to ensure consistency and quality across our build and deployment processes, supporting both GitHub Actions and Azure DevOps pipelines.
+
+## Available Rules
+
+### [.NET Build System Rules](./dotnet-build.mdc)
+Comprehensive guidelines for .NET build systems, covering:
+- Core build philosophy and best practices
+- Project structure and required files
+- Build script organization
+- Version management
+- CI/CD pipeline configuration for both GitHub Actions and Azure DevOps
+- Cross-platform build compatibility
+
+This rule applies to solution files (`.sln`), project files (`.csproj`, `.fsproj`), build configuration files, and CI/CD pipeline definitions (`.github/workflows/*.yaml` and `.azure/*.yaml`).
+
+### [Code Signing Rules](./code-signing.mdc)
+Best practices and configuration guidelines for .NET code signing, including:
+- SignClient configuration
+- Security best practices
+- CI/CD integration for code signing in both GitHub Actions and Azure DevOps
+- Credential management
+- Audit logging requirements
+
+This rule applies to signing configuration files (`signsettings.json`, `appsettings.json`) and package files (`.nupkg`).
+
+## Using These Rules
+
+These rules are automatically enforced through Cursor when working with relevant files. The rules provide inline guidance and validation to ensure your build and deployment configurations follow our established best practices, regardless of whether you're using GitHub Actions or Azure DevOps as your CI/CD platform.
+
+For more information about our CI/CD practices or to propose changes to these rules, please contact the DevOps team. 

--- a/ci-cd/code-signing.mdc
+++ b/ci-cd/code-signing.mdc
@@ -1,0 +1,114 @@
+---
+description: Rules and best practices for .NET code signing
+applies_to:
+  - "**/signsettings.json"
+  - "**/appsettings.json"
+  - "**/*.nupkg"
+triggers:
+  - file_pattern: "**/signsettings.json"
+    exists: true
+  - file_pattern: "**/appsettings.json"
+    content_pattern: "SignClient"
+---
+
+# .NET Code Signing Rules and Best Practices
+
+## Prerequisites
+These rules only apply when one of the following exists:
+- `signsettings.json`
+- `appsettings.json` with a `SignClient` section
+
+## Code Signing Configuration
+
+### SignClient Configuration
+```json
+{
+  "SignClient": {
+    "AzureAd": {
+      "AADInstance": "https://login.microsoftonline.com/",
+      "ClientId": "[configured in CI]",
+      "TenantId": "[configured in CI]"
+    },
+    "Service": {
+      "Url": "https://signing-service.example.com/",
+      "ResourceId": "[configured in CI]"
+    }
+  }
+}
+```
+
+## Security Best Practices
+1. Never commit signing credentials to source control
+2. Store signing credentials in CI/CD secret variables
+3. Use environment-specific signing configurations
+4. Implement proper credential rotation
+5. Log signing operations for audit purposes
+
+## CI/CD Integration
+
+### GitHub Actions Example
+```yaml
+jobs:
+  sign:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Install SignClient
+      run: dotnet tool install --global SignClient
+    
+    - name: Sign NuGet Packages
+      run: |
+        SignClient sign `
+          --config signsettings.json `
+          --input "**/*.nupkg" `
+          --secret "${{ secrets.SIGN_CLIENT_SECRET }}" `
+          --name "MyProject" `
+          --description "Official release package"
+```
+
+### Azure DevOps Example
+```yaml
+steps:
+- task: UseDotNet@2
+  inputs:
+    useGlobalJson: true
+
+- script: dotnet tool install --global SignClient
+  displayName: 'Install SignClient'
+
+- powershell: |
+    SignClient sign `
+      --config signsettings.json `
+      --input "$(Build.ArtifactStagingDirectory)/*.nupkg" `
+      --secret "$(SignClientSecret)" `
+      --name "$(Build.DefinitionName)" `
+      --description "Official release package"
+  displayName: 'Sign Packages'
+  env:
+    SignClientSecret: $(SignClientSecret)
+```
+
+## Verification
+1. Implement post-signing verification
+2. Check signature validity before publishing
+3. Include signature verification in test pipeline
+4. Document signature verification process
+
+## Package Publishing
+1. Only publish signed packages for releases
+2. Implement signature verification before publishing
+3. Maintain signed package archive
+4. Document package signature in release notes
+
+## Troubleshooting
+1. Common signing errors and solutions
+2. Credential validation steps
+3. Service connectivity issues
+4. Certificate expiration handling
+
+## Maintenance
+1. Regular credential rotation schedule
+2. Certificate expiration monitoring
+3. Signing service health checks
+4. Audit log review process 

--- a/ci-cd/dotnet-build.mdc
+++ b/ci-cd/dotnet-build.mdc
@@ -14,34 +14,81 @@ applies_to:
 # .NET Build System Rules and Best Practices
 
 ## Core Build Philosophy
+
+### ✅ DO
 - Use native `dotnet` CLI commands as the primary build mechanism
-- Avoid complex build systems like CAKE, FAKE, or NUKE
 - Keep build scripts simple, maintainable, and cross-platform compatible
 - Use PowerShell for custom build tasks that can't be handled by `dotnet` CLI
+- Maintain clear separation between build, test, and release processes
+- Document all build prerequisites and requirements
+
+### ❌ DON'T
+- Use complex build systems like CAKE, FAKE, or NUKE
+- Mix build and deployment logic in the same scripts
+- Hardcode environment-specific paths or settings
+- Implement complex logic in YAML pipelines (use PowerShell scripts instead)
+- Duplicate build logic across different files
 
 ## Project Structure
 
 > [!IMPORTANT]
-> Don't just create new files willy-nilly, always look to see what exists first before deciding to create something new.
+> Don't create new files without first checking existing ones. Build system files should follow a consistent, predictable structure.
 
-### Required Files
+### Required Files and Their Purposes
 ```
 ├── Directory.Build.props       # Central version and package metadata
+├── Directory.Packages.props    # Centralized package version management
+├── global.json                # SDK version pinning
 ├── RELEASE_NOTES.md           # Version history and release notes
-├── build.ps1                  # Main build script
+├── build.ps1                  # Version management script (minimal)
 ├── scripts/                   # PowerShell helper scripts
 │   ├── getReleaseNotes.ps1    # Parse release notes
 │   ├── bumpVersion.ps1        # Update assembly versions
+│   ├── integration-tests.ps1  # Integration test runner
 │   └── *.ps1                 # Other build helper scripts
-├── .github/workflows/         # GitHub Actions workflows
-│   ├── pr_validation.yaml    # PR and branch validation
-│   └── release.yaml         # Release workflow
-└── .azure/                   # Azure DevOps pipelines (if used)
-    └── *.yaml               # Pipeline definitions
+├── build-system/             # CI/CD pipeline definitions
+│   ├── azure-pipeline.template.yaml  # Shared pipeline template
+│   ├── windows-pr-validation.yaml    # Windows PR validation
+│   ├── linux-pr-validation.yaml      # Linux PR validation
+│   └── windows-release.yaml          # Release pipeline
+└── .github/workflows/        # GitHub Actions (if used)
+    ├── pr-validation.yaml    # PR validation
+    └── release.yaml          # Release workflow
 ```
 
-## Release Notes Format
-RELEASE_NOTES.md should follow this format:
+### File Responsibilities
+
+#### Directory.Build.props
+- Central version management
+- Package metadata
+- Common build properties
+- Shared package versions
+
+Example:
+```xml
+<Project>
+  <PropertyGroup>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <PackageReleaseNotes><!-- Auto-updated by build.ps1 --></PackageReleaseNotes>
+    <Authors>Your Company</Authors>
+    <Copyright>© $([System.DateTime]::Now.Year) Your Company</Copyright>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/org/repo</PackageProjectUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryUrl>https://github.com/org/repo.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+  </PropertyGroup>
+  
+  <!-- Package versions -->
+  <PropertyGroup>
+    <MicrosoftExtensionsVersion>8.0.0</MicrosoftExtensionsVersion>
+    <XunitVersion>2.7.0</XunitVersion>
+  </PropertyGroup>
+</Project>
+```
+
+#### RELEASE_NOTES.md
+Must follow this exact format for automated parsing:
 ```markdown
 #### 1.2.3 March 14 2024 ####
 * First change
@@ -51,165 +98,777 @@ RELEASE_NOTES.md should follow this format:
 * Previous changes
 ```
 
-This format is used by the build system to:
-1. Extract the current version number
-2. Update Directory.Build.props
-3. Generate release notes for NuGet packages
-4. Create GitHub releases
+> [!WARNING]
+> Common mistakes to avoid:
+> - Extra blank lines between version and changes
+> - Missing space between version and date
+> - Incorrect number of # symbols
+> - Missing bullet points for changes
 
-## Build Script Guidelines
+## Build Scripts
 
-### Main build.ps1
-- Should be minimal and focused on version management
-- Primary responsibilities:
-  1. Parse RELEASE_NOTES.md
-  2. Update version in Directory.Build.props
-  3. Call dotnet commands for build/test/pack
+### build.ps1
+Keep this script minimal. Its only job should be version management:
 
-Example build.ps1 structure:
 ```powershell
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+# Import helper functions
 . "$PSScriptRoot\scripts\getReleaseNotes.ps1"
 . "$PSScriptRoot\scripts\bumpVersion.ps1"
 
 # Update version information
-$releaseNotes = Get-ReleaseNotes -MarkdownFile "RELEASE_NOTES.md"
-UpdateVersionAndReleaseNotes -ReleaseNotesResult $releaseNotes -XmlFilePath "Directory.Build.props"
+$releaseNotes = Get-ReleaseNotes -MarkdownFile (Join-Path -Path $PSScriptRoot -ChildPath "RELEASE_NOTES.md")
+UpdateVersionAndReleaseNotes -ReleaseNotesResult $releaseNotes -XmlFilePath (Join-Path -Path $PSScriptRoot -ChildPath "src\Directory.Build.props")
 
-# Build commands
-dotnet build -c Release
-dotnet test -c Release
-dotnet pack -c Release
+Write-Output "Updated version to $($releaseNotes.Version)"
 ```
 
-## CI/CD Patterns
+### Integration Tests
+Place integration tests in a dedicated script with clear error handling:
 
-### GitHub Actions
+```powershell
+[CmdletBinding()]
+param(
+    [ValidateSet("Release", "Debug")]
+    [string]$Configuration = "Release"
+)
 
-#### Pull Request Validation (pr_validation.yaml)
+# Track test results
+$script:hasUnexpectedFailures = $false
+$script:totalTests = 0
+$script:passedTests = 0
+$script:failedTests = 0
+
+function Invoke-Test {
+    param(
+        [string]$TestName,
+        [scriptblock]$TestScript,
+        [bool]$ExpectFailure = $false
+    )
+    
+    $script:totalTests++
+    try {
+        & $TestScript
+        if ($LASTEXITCODE -ne 0 -and -not $ExpectFailure) {
+            $script:hasUnexpectedFailures = $true
+            $script:failedTests++
+        } else {
+            $script:passedTests++
+        }
+    }
+    catch {
+        $script:hasUnexpectedFailures = $true
+        $script:failedTests++
+    }
+}
+
+# Run all tests before exiting
+exit $script:hasUnexpectedFailures ? 1 : 0
+```
+
+## CI/CD Pipeline Best Practices
+
+### ✅ DO
+- Use pipeline templates for shared configuration
+- Keep pipeline files in `build-system/` directory
+- Use consistent naming conventions
+- Include clear display names for all steps
+- Set appropriate timeouts
+- Configure proper trigger conditions
+- Use matrix builds for cross-platform testing
+- Publish test results and artifacts
+- Set up proper dependency caching
+
+### ❌ DON'T
+- Put complex logic in YAML files
+- Duplicate steps across pipelines
+- Use inline scripts for complex operations
+- Hardcode version numbers or configuration
+- Mix PR validation and release pipelines
+- Ignore test failures
+- Skip publishing test results
+
+### Azure Pipeline Template Example
 ```yaml
-name: pr_validation
-
-on:
-  push:
-    branches: [ master, main, dev ]
-  pull_request:
-    branches: [ master, main, dev ]
+parameters:
+  name: ''
+  vmImage: ''
+  timeoutInMinutes: 10
+  runIntegrationTests: false
 
 jobs:
-  test:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    
+  - job: ${{ parameters.name }}
+    timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+    pool:
+      vmImage: ${{ parameters.vmImage }}
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-dotnet@v4
-      with:
-        global-json-file: "./global.json"
-    
-    - run: ./build.ps1
-    - run: dotnet test -c Release --verbosity normal
-    - run: dotnet pack -c Release
+      - checkout: self
+        clean: false
+        submodules: recursive
+        
+      - task: UseDotNet@2
+        displayName: 'Use .NET SDK'
+        inputs:
+          useGlobalJson: true
+          
+      # Version bump
+      - task: PowerShell@2
+        displayName: 'Update version'
+        inputs:
+          filePath: './build.ps1'
+          
+      # Build and test
+      - script: dotnet build -c Release
+        displayName: 'Build solution'
+          
+      - script: dotnet test -c Release --no-build --logger:trx
+        displayName: 'Run unit tests'
+          
+      # Integration tests
+      - task: PowerShell@2
+        displayName: 'Run integration tests'
+        condition: eq(${{ parameters.runIntegrationTests }}, true)
+        inputs:
+          filePath: './scripts/integration-tests.ps1'
+          arguments: '-Configuration Release'
+          
+      # Package
+      - script: dotnet pack -c Release -o $(Build.ArtifactStagingDirectory)
+        displayName: 'Create packages'
+        condition: succeeded()
+          
+      # Publish results
+      - task: PublishTestResults@2
+        displayName: 'Publish test results'
+        condition: always()
+        inputs:
+          testRunner: VSTest
+          testResultsFiles: '**/*.trx'
+          failTaskOnFailedTests: true
 ```
 
-#### Release Workflow (release.yaml)
-```yaml
-name: release
-
-on:
-  push:
-    tags: ['v*']
-
-jobs:
-  publish:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-dotnet@v4
-      with:
-        global-json-file: "./global.json"
-    
-    - run: ./build.ps1
-    - run: dotnet pack -c Release
-    
-    - name: Push to NuGet
-      run: dotnet nuget push "**/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
-    
-    - name: Create GitHub Release
-      uses: softprops/action-gh-release@v1
-      with:
-        files: "**/*.nupkg"
-        body_path: RELEASE_NOTES.md
-```
-
-### Azure DevOps Pipelines
-
-#### Build and Test Pipeline (.azure/build.yaml)
+### PR Validation Pipeline
 ```yaml
 trigger:
   branches:
-    include:
-      - master
-      - dev
-      - main
-pr: none
+    include: [ dev, master ]
+  paths:
+    exclude: [ '*.md', 'docs/*' ]
 
-pool:
-  vmImage: 'windows-latest'
+pr:
+  autoCancel: true
+  branches:
+    include: [ dev, master ]
+
+jobs:
+  - template: azure-pipeline.template.yaml
+    parameters:
+      name: 'Windows'
+      vmImage: 'windows-latest'
+      runIntegrationTests: true
+```
+
+### Release Pipeline
+```yaml
+trigger:
+  branches:
+    include: [ refs/tags/* ]
+  paths:
+    exclude: [ '*.md', 'docs/*' ]
+
+variables:
+  - group: nuget-keys
+  - name: projectName
+    value: YourProject
 
 steps:
-- task: UseDotNet@2
-  inputs:
-    useGlobalJson: true
+  - task: UseDotNet@2
+    inputs:
+      useGlobalJson: true
 
-- powershell: ./build.ps1
-  displayName: 'Update Release Notes'
+  - script: ./build.ps1
+    displayName: 'Update version'
 
-- script: dotnet build -c Release
-  displayName: 'Build'
-
-- script: dotnet test -c Release
-  displayName: 'Test'
-
-- script: dotnet pack -c Release -o $(Build.ArtifactStagingDirectory)
-  displayName: 'Pack'
-
-- task: PublishBuildArtifacts@1
-  inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-    ArtifactName: 'nuget'
+  - script: |
+      dotnet pack -c Release -o $(Build.ArtifactStagingDirectory)
+      dotnet nuget push "$(Build.ArtifactStagingDirectory)/*.nupkg" --api-key $(nugetKey) --source https://api.nuget.org/v3/index.json
+    displayName: 'Create and publish packages'
 ```
+
+## Common Patterns and Anti-patterns
+
+### Version Management
+
+✅ DO:
+- Use RELEASE_NOTES.md as the single source of truth
+- Automate version updates via build.ps1
+- Include detailed release notes for each version
+- Follow semantic versioning
+- Update all version references consistently
+
+❌ DON'T:
+- Manually edit version numbers
+- Store versions in multiple places
+- Skip release notes
+- Use inconsistent version formats
+- Forget to update package versions
+
+### Build Process
+
+✅ DO:
+- Build before running tests
+- Use `--no-build` for test/pack after build
+- Set appropriate configuration
+- Enable deterministic builds
+- Cache dependencies
+- Use consistent output directories
+
+❌ DON'T:
+- Mix Debug/Release artifacts
+- Skip test runs
+- Ignore build warnings
+- Use platform-specific commands
+- Hardcode paths
+
+### Testing
+
+✅ DO:
+- Run all tests before exit
+- Publish test results
+- Use appropriate test loggers
+- Set test timeouts
+- Handle expected failures properly
+- Separate unit and integration tests
+
+❌ DON'T:
+- Ignore test failures
+- Skip result publishing
+- Mix test types
+- Use platform-specific test runners
+- Leave failing tests unhandled
+
+### Package Creation
+
+✅ DO:
+- Include symbols packages
+- Set appropriate package metadata
+- Use consistent output directory
+- Verify package contents
+- Include documentation files
+
+❌ DON'T:
+- Skip symbol packages
+- Hardcode version numbers
+- Mix package sources
+- Ignore package validation
+- Skip README files
 
 ## Migration Guidelines
 
-### Moving from CAKE/FAKE/NUKE
-1. Identify build tasks in existing system
-2. Map complex tasks to PowerShell scripts
-3. Replace build system commands with native dotnet CLI
-4. Move signing configuration to separate file
-5. Update CI/CD pipeline to use new build structure
+When moving from complex build systems to `dotnet` CLI:
 
-### Directory Migration
-When moving Azure DevOps pipeline files:
-1. Check for existing pipeline files in non-standard locations
-2. Before moving to `.azure/`, confirm with team
-3. Update pipeline connection in Azure DevOps portal
-4. Test pipeline after migration
+1. **Analyze Current Build**
+   - List all build tasks
+   - Identify custom logic
+   - Document dependencies
+   - Note platform-specific code
 
-## Code Signing
-- Keep signing configuration separate
-- Only include when `signsettings.json` or `SignClient` section exists
-- Use dedicated signing rules file for these scenarios
+2. **Plan Migration**
+   - Map tasks to `dotnet` commands
+   - Identify scripts needed
+   - Plan folder structure
+   - Set up new pipelines
 
-## Additional Best Practices
-1. Use `Directory.Build.props` for central version management
-2. Keep PowerShell scripts focused and modular
-3. Implement cross-platform compatibility checks
-4. Use `dotnet tool` for specialized build tools
-5. Maintain clear separation between build and release pipelines
-6. Document build prerequisites in README.md
-7. Include example commands for local development
-8. Use matrix builds for multi-platform testing
-9. Implement proper error handling in PowerShell scripts
-10. Keep build artifacts in `./artifacts` or `./bin` directory 
+3. **Execute Migration**
+   - Create new script structure
+   - Convert build tasks
+   - Update CI/CD pipelines
+   - Test thoroughly
+   - Run in parallel with old system
+
+4. **Validate**
+   - Cross-platform testing
+   - Build verification
+   - Package validation
+   - Pipeline testing
+   - Documentation update
+
+## Best Practices Summary
+
+1. **Script Organization**
+   - One purpose per script
+   - Clear error handling
+   - Consistent naming
+   - Proper documentation
+   - Cross-platform compatibility
+
+2. **Pipeline Structure**
+   - Template-based design
+   - Clear step organization
+   - Proper condition handling
+   - Result publishing
+   - Artifact management
+
+3. **Version Control**
+   - Single source of truth
+   - Automated updates
+   - Consistent formatting
+   - Clear documentation
+   - Proper validation
+
+4. **Testing Strategy**
+   - Separate test types
+   - Clear result reporting
+   - Proper error handling
+   - Complete coverage
+   - Performance consideration
+
+5. **Documentation**
+   - Clear prerequisites
+   - Step-by-step guides
+   - Troubleshooting tips
+   - Example commands
+   - Version history
+
+## Version Management Helper Functions
+
+### Release Notes Parser (getReleaseNotes.ps1)
+This script parses the RELEASE_NOTES.md file to extract version information and notes:
+
+```powershell
+function Get-ReleaseNotes {
+    param (
+        [Parameter(Mandatory=$true)]
+        [string]$MarkdownFile
+    )
+
+    # Read markdown file content
+    $content = Get-Content -Path $MarkdownFile -Raw
+
+    # Split content based on headers
+    $sections = $content -split "####"
+
+    # Output object to store result
+    $outputObject = [PSCustomObject]@{
+        Version       = $null
+        Date          = $null
+        ReleaseNotes  = $null
+    }
+
+    # Check if we have at least 3 sections (1. Before the header, 2. Header, 3. Release notes)
+    if ($sections.Count -ge 3) {
+        $header = $sections[1].Trim()
+        $releaseNotes = $sections[2].Trim()
+
+        # Extract version and date from the header
+        $headerParts = $header -split " ", 2
+        if ($headerParts.Count -eq 2) {
+            $outputObject.Version = $headerParts[0]
+            $outputObject.Date = $headerParts[1]
+        }
+
+        $outputObject.ReleaseNotes = $releaseNotes
+    }
+
+    return $outputObject
+}
+```
+
+### Version Updater (bumpVersion.ps1)
+This script updates the version and release notes in Directory.Build.props:
+
+```powershell
+function UpdateVersionAndReleaseNotes {
+    param (
+        [Parameter(Mandatory=$true)]
+        [PSCustomObject]$ReleaseNotesResult,
+
+        [Parameter(Mandatory=$true)]
+        [string]$XmlFilePath
+    )
+
+    if (-not (Test-Path $XmlFilePath)) {
+        throw "Directory.Build.props not found at: $XmlFilePath"
+    }
+
+    try {
+        # Load XML
+        $xmlContent = New-Object XML
+        $xmlContent.Load($XmlFilePath)
+
+        # Update VersionPrefix and PackageReleaseNotes
+        $versionPrefixElement = $xmlContent.SelectSingleNode("//VersionPrefix")
+        if ($null -eq $versionPrefixElement) {
+            throw "VersionPrefix element not found in Directory.Build.props"
+        }
+        $versionPrefixElement.InnerText = $ReleaseNotesResult.Version
+
+        $packageReleaseNotesElement = $xmlContent.SelectSingleNode("//PackageReleaseNotes")
+        if ($null -eq $packageReleaseNotesElement) {
+            throw "PackageReleaseNotes element not found in Directory.Build.props"
+        }
+        $packageReleaseNotesElement.InnerText = $ReleaseNotesResult.ReleaseNotes
+
+        # Save the updated XML
+        $xmlContent.Save($XmlFilePath)
+    }
+    catch {
+        throw "Failed to update Directory.Build.props: $_"
+    }
+}
+```
+
+### Finding Directory.Build.props
+When working with complex repository structures, you might need to locate the correct Directory.Build.props file. Here's a helper function:
+
+```powershell
+function Find-DirectoryBuildProps {
+    param (
+        [Parameter(Mandatory=$true)]
+        [string]$StartPath,
+        
+        [Parameter(Mandatory=$false)]
+        [string]$FileName = "Directory.Build.props"
+    )
+    
+    # First check if file exists in start path
+    $directPath = Join-Path $StartPath $FileName
+    if (Test-Path $directPath) {
+        return $directPath
+    }
+    
+    # Check src directory if it exists
+    $srcPath = Join-Path $StartPath "src" $FileName
+    if (Test-Path $srcPath) {
+        return $srcPath
+    }
+    
+    # Search recursively up to 2 levels deep
+    $searchResults = Get-ChildItem -Path $StartPath -Filter $FileName -Recurse -Depth 2 |
+        Where-Object { $_.Name -eq $FileName }
+    
+    if ($searchResults.Count -eq 0) {
+        throw "Could not find $FileName in or below $StartPath"
+    }
+    if ($searchResults.Count -gt 1) {
+        Write-Warning "Found multiple $FileName files. Using the first one found."
+        $searchResults | ForEach-Object { Write-Warning "Found: $($_.FullName)" }
+    }
+    
+    return $searchResults[0].FullName
+}
+```
+
+### Complete Version Update Example
+Here's how to use these functions together in your build script:
+
+```powershell
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$Configuration = "Release"
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Import helper functions
+. "$PSScriptRoot\scripts\getReleaseNotes.ps1"
+. "$PSScriptRoot\scripts\bumpVersion.ps1"
+
+try {
+    # Find Directory.Build.props
+    $buildPropsPath = Find-DirectoryBuildProps -StartPath $PSScriptRoot
+    Write-Host "Found Directory.Build.props at: $buildPropsPath"
+    
+    # Parse release notes
+    $releaseNotesPath = Join-Path $PSScriptRoot "RELEASE_NOTES.md"
+    $releaseNotes = Get-ReleaseNotes -MarkdownFile $releaseNotesPath
+    
+    if ($null -eq $releaseNotes.Version) {
+        throw "Failed to parse version from RELEASE_NOTES.md"
+    }
+    
+    Write-Host "Updating to version $($releaseNotes.Version)"
+    
+    # Update version information
+    UpdateVersionAndReleaseNotes -ReleaseNotesResult $releaseNotes -XmlFilePath $buildPropsPath
+    
+    Write-Host "Successfully updated version and release notes"
+}
+catch {
+    Write-Error "Failed to update version: $_"
+    exit 1
+}
+```
+
+### Common Version Management Issues
+
+#### ✅ DO:
+- Validate release notes format before parsing
+- Handle multiple Directory.Build.props files gracefully
+- Provide clear error messages for parsing failures
+- Back up files before making changes
+- Log all version updates
+
+#### ❌ DON'T:
+- Assume file locations without verification
+- Skip error handling in XML operations
+- Overwrite files without validation
+- Ignore malformed release notes
+- Make partial updates
+
+### Troubleshooting Version Updates
+
+1. **Release Notes Not Parsed**
+   - Check exact format matches template
+   - Verify no extra spaces in header
+   - Ensure proper line endings (CRLF vs LF)
+   - Validate bullet point format
+
+2. **Directory.Build.props Not Found**
+   - Check repository structure
+   - Verify search path is correct
+   - Look for case sensitivity issues
+   - Check file permissions
+
+3. **XML Update Failures**
+   - Verify XML is well-formed
+   - Check for required elements
+   - Ensure proper namespace handling
+   - Validate XML schema
+
+4. **Version Format Issues**
+   - Ensure semantic versioning
+   - Check for pre-release tag format
+   - Validate build metadata
+   - Verify version string parsing 
+
+## Command Delegation and Error Handling
+
+### When to Use `dotnet` CLI vs PowerShell
+
+#### Use `dotnet` CLI Directly For:
+- Building projects and solutions
+- Running tests
+- Creating NuGet packages
+- Publishing applications
+- Restoring packages
+- Managing project references
+
+Example of proper `dotnet` CLI usage:
+```powershell
+# Direct command - no need for script wrapping
+dotnet build -c Release
+
+# Test with proper logger configuration
+dotnet test -c Release --no-build --logger:trx
+
+# Package creation with symbols
+dotnet pack -c Release --include-symbols
+```
+
+#### Use PowerShell Scripts For:
+- Version management and release notes parsing
+- Complex integration test orchestration
+- Environment setup and validation
+- Tasks requiring file system operations
+- Multi-step processes with error aggregation
+- Custom build task orchestration
+
+### Error Handling Patterns
+
+#### ❌ Anti-Pattern: Shell Script Error Masking
+```powershell
+# DON'T DO THIS: Masks real exit codes
+try {
+    dotnet test
+    if ($LASTEXITCODE -ne 0) { 
+        Write-Warning "Tests failed but continuing..."
+        $LASTEXITCODE = 0  # WRONG: Masks the real failure
+    }
+}
+catch {
+    Write-Warning "Error occurred but continuing..."
+}
+```
+
+#### ✅ Correct Pattern: Preserve Exit Codes
+```powershell
+# DO THIS: Preserves exit codes and handles expected failures properly
+function Invoke-Test {
+    param(
+        [string]$TestName,
+        [scriptblock]$TestScript,
+        [bool]$ExpectFailure = $false
+    )
+    
+    try {
+        & $TestScript
+        $exitCode = $LASTEXITCODE
+        
+        if ($exitCode -ne 0 -and -not $ExpectFailure) {
+            Write-Host "Test failed: $TestName (Exit code: $exitCode)" -ForegroundColor Red
+            return $false
+        }
+        if ($exitCode -eq 0 -and $ExpectFailure) {
+            Write-Host "Test succeeded unexpectedly: $TestName" -ForegroundColor Red
+            return $false
+        }
+        
+        Write-Host "Test completed as expected: $TestName" -ForegroundColor Green
+        return $true
+    }
+    catch {
+        Write-Host "Test threw exception: $TestName`n$_" -ForegroundColor Red
+        return $false
+    }
+}
+```
+
+### Command Delegation Guidelines
+
+#### ✅ DO:
+- Let `dotnet` CLI handle all build operations
+- Use `--no-build` when running tests after build
+- Pass through exit codes faithfully
+- Collect all errors before exiting
+- Use proper logging and verbosity settings
+
+#### ❌ DON'T:
+- Wrap simple `dotnet` commands in scripts
+- Mask or ignore exit codes
+- Mix build configurations
+- Handle MSBuild properties in scripts
+- Reimplement `dotnet` CLI functionality
+
+### Examples of Proper Delegation
+
+#### Build and Test Pipeline
+```powershell
+# DON'T DO THIS:
+function Build-AndTest {
+    # Wrong: Unnecessary wrapping of dotnet commands
+    dotnet restore
+    if ($LASTEXITCODE -eq 0) {
+        dotnet build
+        if ($LASTEXITCODE -eq 0) {
+            dotnet test
+        }
+    }
+}
+
+# DO THIS INSTEAD:
+# In pipeline YAML:
+steps:
+  - script: dotnet build -c Release
+    displayName: 'Build'
+    
+  - script: dotnet test -c Release --no-build
+    displayName: 'Test'
+```
+
+#### Integration Test Runner
+```powershell
+# Proper balance of script logic and dotnet commands
+function Start-IntegrationTest {
+    param(
+        [string]$ProjectPath,
+        [string]$Configuration = "Release"
+    )
+    
+    # Script handles:
+    # 1. Test environment setup
+    # 2. Result aggregation
+    # 3. Error tracking
+    $results = @{
+        Passed = 0
+        Failed = 0
+        Errors = @()
+    }
+    
+    # Let dotnet handle the actual operations
+    $tests = @(
+        @{ Name = "Basic"; Args = @("--filter", "Category=Basic") }
+        @{ Name = "Extended"; Args = @("--filter", "Category=Extended") }
+    )
+    
+    foreach ($test in $tests) {
+        Write-Host "Running $($test.Name) tests..."
+        
+        # Delegate to dotnet for the actual test execution
+        dotnet test $ProjectPath -c $Configuration --no-build @($test.Args)
+        
+        if ($LASTEXITCODE -ne 0) {
+            $results.Failed++
+            $results.Errors += "Test '$($test.Name)' failed with exit code $LASTEXITCODE"
+        } else {
+            $results.Passed++
+        }
+    }
+    
+    # Script handles result reporting
+    if ($results.Failed -gt 0) {
+        Write-Host "Test Summary: $($results.Passed) passed, $($results.Failed) failed"
+        $results.Errors | ForEach-Object { Write-Host "  $_" -ForegroundColor Red }
+        exit 1
+    }
+    
+    Write-Host "All tests passed!" -ForegroundColor Green
+    exit 0
+}
+```
+
+### Error Code Handling
+
+#### Exit Code Principles
+1. Never mask unexpected failures
+2. Track expected failures separately
+3. Run all tests before exiting
+4. Provide clear error summaries
+5. Use proper exit codes
+
+```powershell
+# Example of proper error tracking
+$script:hasUnexpectedFailures = $false
+$script:expectedFailures = 0
+$script:totalTests = 0
+
+try {
+    # Run all tests even if some fail
+    foreach ($test in $tests) {
+        $script:totalTests++
+        
+        & $test.Command
+        if ($LASTEXITCODE -ne 0) {
+            if ($test.ExpectFailure) {
+                $script:expectedFailures++
+            } else {
+                $script:hasUnexpectedFailures = $true
+            }
+        }
+    }
+    
+    # Exit with failure only if we had unexpected failures
+    exit $script:hasUnexpectedFailures ? 1 : 0
+}
+catch {
+    Write-Error "Test execution failed: $_"
+    exit 1
+}
+```
+
+### When to Create Helper Scripts
+
+Create PowerShell scripts only when you need to:
+1. Orchestrate multiple `dotnet` commands
+2. Set up test environments
+3. Aggregate results from multiple operations
+4. Handle expected failures
+5. Provide custom logging or reporting
+6. Manage file system operations
+
+Otherwise, use `dotnet` CLI directly in your build pipeline. 

--- a/ci-cd/dotnet-build.mdc
+++ b/ci-cd/dotnet-build.mdc
@@ -1,0 +1,215 @@
+---
+description: Rules and best practices for .NET build systems
+applies_to: 
+  - "**/*.sln"
+  - "**/*.csproj"
+  - "**/*.fsproj"
+  - "**/Directory.Build.props"
+  - "**/build.ps1"
+  - "**/.github/workflows/*.yaml"
+  - "**/.azure/*.yaml"
+  - "**/RELEASE_NOTES.md"
+---
+
+# .NET Build System Rules and Best Practices
+
+## Core Build Philosophy
+- Use native `dotnet` CLI commands as the primary build mechanism
+- Avoid complex build systems like CAKE, FAKE, or NUKE
+- Keep build scripts simple, maintainable, and cross-platform compatible
+- Use PowerShell for custom build tasks that can't be handled by `dotnet` CLI
+
+## Project Structure
+
+> [!IMPORTANT]
+> Don't just create new files willy-nilly, always look to see what exists first before deciding to create something new.
+
+### Required Files
+```
+├── Directory.Build.props       # Central version and package metadata
+├── RELEASE_NOTES.md           # Version history and release notes
+├── build.ps1                  # Main build script
+├── scripts/                   # PowerShell helper scripts
+│   ├── getReleaseNotes.ps1    # Parse release notes
+│   ├── bumpVersion.ps1        # Update assembly versions
+│   └── *.ps1                 # Other build helper scripts
+├── .github/workflows/         # GitHub Actions workflows
+│   ├── pr_validation.yaml    # PR and branch validation
+│   └── release.yaml         # Release workflow
+└── .azure/                   # Azure DevOps pipelines (if used)
+    └── *.yaml               # Pipeline definitions
+```
+
+## Release Notes Format
+RELEASE_NOTES.md should follow this format:
+```markdown
+#### 1.2.3 March 14 2024 ####
+* First change
+* Second change
+
+#### 1.2.2 March 10 2024 ####
+* Previous changes
+```
+
+This format is used by the build system to:
+1. Extract the current version number
+2. Update Directory.Build.props
+3. Generate release notes for NuGet packages
+4. Create GitHub releases
+
+## Build Script Guidelines
+
+### Main build.ps1
+- Should be minimal and focused on version management
+- Primary responsibilities:
+  1. Parse RELEASE_NOTES.md
+  2. Update version in Directory.Build.props
+  3. Call dotnet commands for build/test/pack
+
+Example build.ps1 structure:
+```powershell
+. "$PSScriptRoot\scripts\getReleaseNotes.ps1"
+. "$PSScriptRoot\scripts\bumpVersion.ps1"
+
+# Update version information
+$releaseNotes = Get-ReleaseNotes -MarkdownFile "RELEASE_NOTES.md"
+UpdateVersionAndReleaseNotes -ReleaseNotesResult $releaseNotes -XmlFilePath "Directory.Build.props"
+
+# Build commands
+dotnet build -c Release
+dotnet test -c Release
+dotnet pack -c Release
+```
+
+## CI/CD Patterns
+
+### GitHub Actions
+
+#### Pull Request Validation (pr_validation.yaml)
+```yaml
+name: pr_validation
+
+on:
+  push:
+    branches: [ master, main, dev ]
+  pull_request:
+    branches: [ master, main, dev ]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: "./global.json"
+    
+    - run: ./build.ps1
+    - run: dotnet test -c Release --verbosity normal
+    - run: dotnet pack -c Release
+```
+
+#### Release Workflow (release.yaml)
+```yaml
+name: release
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: "./global.json"
+    
+    - run: ./build.ps1
+    - run: dotnet pack -c Release
+    
+    - name: Push to NuGet
+      run: dotnet nuget push "**/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+    
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: "**/*.nupkg"
+        body_path: RELEASE_NOTES.md
+```
+
+### Azure DevOps Pipelines
+
+#### Build and Test Pipeline (.azure/build.yaml)
+```yaml
+trigger:
+  branches:
+    include:
+      - master
+      - dev
+      - main
+pr: none
+
+pool:
+  vmImage: 'windows-latest'
+
+steps:
+- task: UseDotNet@2
+  inputs:
+    useGlobalJson: true
+
+- powershell: ./build.ps1
+  displayName: 'Update Release Notes'
+
+- script: dotnet build -c Release
+  displayName: 'Build'
+
+- script: dotnet test -c Release
+  displayName: 'Test'
+
+- script: dotnet pack -c Release -o $(Build.ArtifactStagingDirectory)
+  displayName: 'Pack'
+
+- task: PublishBuildArtifacts@1
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+    ArtifactName: 'nuget'
+```
+
+## Migration Guidelines
+
+### Moving from CAKE/FAKE/NUKE
+1. Identify build tasks in existing system
+2. Map complex tasks to PowerShell scripts
+3. Replace build system commands with native dotnet CLI
+4. Move signing configuration to separate file
+5. Update CI/CD pipeline to use new build structure
+
+### Directory Migration
+When moving Azure DevOps pipeline files:
+1. Check for existing pipeline files in non-standard locations
+2. Before moving to `.azure/`, confirm with team
+3. Update pipeline connection in Azure DevOps portal
+4. Test pipeline after migration
+
+## Code Signing
+- Keep signing configuration separate
+- Only include when `signsettings.json` or `SignClient` section exists
+- Use dedicated signing rules file for these scenarios
+
+## Additional Best Practices
+1. Use `Directory.Build.props` for central version management
+2. Keep PowerShell scripts focused and modular
+3. Implement cross-platform compatibility checks
+4. Use `dotnet tool` for specialized build tools
+5. Maintain clear separation between build and release pipelines
+6. Document build prerequisites in README.md
+7. Include example commands for local development
+8. Use matrix builds for multi-platform testing
+9. Implement proper error handling in PowerShell scripts
+10. Keep build artifacts in `./artifacts` or `./bin` directory 


### PR DESCRIPTION
# Description

Adds build system rules for working with Azure DevOps and GitHub Actions based on my aesthics, which are to avoid `_AKE` build systems and prefer using `dotnet` commands and PowerShell scripts when necessary. Uses a standard `RELEASE_NOTES.md` markdown format for version bumping.

## Type of Change

Please delete options that are not relevant.

- [x] New rule (C#)
- [x] New rule (F#)
- [x] Documentation update
- [x] Other (please describe)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have placed the rule in the correct directory
- [x] I have included "do" and "don't" examples in my rule
- [x] I have provided clear rationale for the rule
- [x] I have updated relevant documentation
- [x] All links in markdown files are valid
- [x] I have read the **CONTRIBUTING.md** document