### PR TITLE
Fix typo in csharp/coding-style.mdc description

### DIFF
--- a/csharp/coding-style.mdc
+++ b/csharp/coding-style.mdc
@@ -1,5 +1,5 @@
 ---
-description: his file provides guidelines for writing clean, maintainable, and idiomatic C# code with a focus on functional patterns and proper abstraction.
+description: This file provides guidelines for writing clean, maintainable, and idiomatic C# code with a focus on functional patterns and proper abstraction.
 globs: *.cs
 alwaysApply: false
 ---


### PR DESCRIPTION
## Summary

Corrects a typo in the frontmatter `description` for `csharp/coding-style.mdc`: **his** → **This**.

## Change

- Single-line fix in YAML frontmatter so the rule description reads correctly in Cursor.

No functional rule content changes.

Made with [Cursor](https://cursor.com)